### PR TITLE
feat(ocr): 增加 OCR 识别并绘制 Base64 图像方法

### DIFF
--- a/smartjavaai-ocr/src/main/java/cn/smartjavaai/ocr/config/OcrRecOptions.java
+++ b/smartjavaai-ocr/src/main/java/cn/smartjavaai/ocr/config/OcrRecOptions.java
@@ -4,6 +4,7 @@ import lombok.Data;
 
 /**
  * OCR 识别配置
+ *
  * @author dwj
  */
 @Data

--- a/smartjavaai-ocr/src/main/java/cn/smartjavaai/ocr/entity/OcrInfo.java
+++ b/smartjavaai-ocr/src/main/java/cn/smartjavaai/ocr/entity/OcrInfo.java
@@ -20,6 +20,7 @@ public class OcrInfo {
 
     private String fullText;
 
+    private String base64Img;
 
 
     public OcrInfo(List<List<OcrItem>> lineList, String fullText) {

--- a/smartjavaai-ocr/src/main/java/cn/smartjavaai/ocr/model/common/recognize/OcrCommonRecModel.java
+++ b/smartjavaai-ocr/src/main/java/cn/smartjavaai/ocr/model/common/recognize/OcrCommonRecModel.java
@@ -98,7 +98,23 @@ public interface OcrCommonRecModel extends AutoCloseable{
     default BufferedImage recognizeAndDraw(BufferedImage sourceImage, int fontSize, OcrRecOptions options){
         throw new UnsupportedOperationException("默认不支持该功能");
     }
+    /**
+     * 识别并绘制Base64结果
+     * @param imageData 图片字节数组
+     * @return
+     */
+    default String recognizeAndDrawToBase64(byte[] imageData, int fontSize, OcrRecOptions options){
+        throw new UnsupportedOperationException("默认不支持该功能");
+    }
 
+    /**
+     * 识别并绘制结果
+     * @param imageData 图片字节数组
+     * @return
+     */
+    default OcrInfo recognizeAndDraw(byte[] imageData, int fontSize, OcrRecOptions options){
+        throw new UnsupportedOperationException("默认不支持该功能");
+    }
 
     default List<OcrInfo> batchRecognize(List<BufferedImage> imageList, OcrRecOptions options) {
         throw new UnsupportedOperationException("默认不支持该功能");


### PR DESCRIPTION
- 在 OcrCommonRecModel 接口中添加了 recognizeAndDrawToBase64 和 recognizeAndDraw 方法
- 在OcrCommonRecModelImpl 类中实现了这两个新方法
- 新增方法支持将识别结果以 Base64 格式返回，便于在网络中传输和使用
- 优化了现有 recognizeAndDraw 方法，使其支持 byte[] 图像数据
- 在 OcrInfo 类中添加了 base64Img 字段，用于存储识别结果的 Base64 图像