### PR TITLE
fix(translator): 修复 RecognitionTranslator 中 BGR/RGB 通道顺序错误

### DIFF
--- a/ocr/src/main/java/cn/smartjavaai/ocr/model/plate/translator/CRNNPlateRecTranslator.java
+++ b/ocr/src/main/java/cn/smartjavaai/ocr/model/plate/translator/CRNNPlateRecTranslator.java
@@ -31,7 +31,8 @@ public class CRNNPlateRecTranslator implements Translator<Image, PlateResult> {
         // Resize to (168, 48)
         NDArray array = input.toNDArray(manager, Image.Flag.COLOR);
         array = NDImageUtils.resize(array, 168, 48);
-
+        // RGB → BGR，与 cv2 对齐
+        array = array.flip(2);
         // Normalize
         array = array.toType(DataType.FLOAT32, false)
                 .div(255f)


### PR DESCRIPTION
问题：
- cv2.imread() 返回 BGR 通道顺序
- DJL Image.toNDArray(manager, Image.Flag.COLOR) 返回 RGB 通道顺序
- 通道不对齐导致归一化结果与 Python 参考实现偏差显著

根本原因：
- 模型训练时使用 OpenCV 读取图像，输入为 BGR 格式
- DJL 未做通道转换直接送入模型，导致推理结果异常
- 实测均值偏差约 1.0（预期 < 0.02）

修复方案：
- 在 toNDArray() 后添加 NDArray.flip(2)，翻转通道顺序 RGB → BGR
- flip 在 resize 之前执行，保证预处理流程与 Python 一致

验证结果：
  Python : mean=-0.4013394  min=-3.0466321  max=2.1347151
  Java   : mean=-0.4169087  min=-2.9247181  max=2.1143961
  Δmean  : 0.016（可接受范围，来自 resize 插值算法差异）

影响范围：RecognitionTranslator#processInput